### PR TITLE
Do not delete the channel when the spool expires.

### DIFF
--- a/src/nsync_callback.erl
+++ b/src/nsync_callback.erl
@@ -99,8 +99,16 @@ handle({cmd, "del", []}) ->
     ok;
 handle({cmd, "del", [<<"ch:", Suffix/binary>> | Args]}) ->
     Id = parse_id(Suffix),
-    ?INFO("at=delete type=channel id=~s", [Id]),
-    ets:delete(channels, Id),
+    Subkey = parse_subkey(Suffix),
+    ?INFO("at=delete type=channel id=~s subkey=~s", [Id, Subkey]),
+    case Subkey of
+      "data" ->
+        ets:delete(channels, Id);
+      "spool" ->
+        ok;
+      _ ->
+        ok
+    end,
     handle({cmd, "del", Args});
 handle({cmd, "del", [<<"tok:", Suffix/binary>> | Args]}) ->
     Id = parse_id(Suffix),
@@ -285,6 +293,10 @@ drain_uri(Dict) ->
 parse_id(Bin) ->
     [Id | _] = binary:split(Bin, <<":">>),
     Id.
+
+parse_subkey(Bin) ->
+    [_ | Subkey] = binary:split(Bin, <<":">>),
+    Subkey.
 
 dict_from_list(List) ->
     dict_from_list(List, dict:new()).


### PR DESCRIPTION
To reproduce the problem, 
1. create a new channel: `curl -d '{"tokens": ["app"]}' http://local:password@10.5.0.4:8001/channels`
2. post a log message: 
    ```
    curl -v \
    -H "Content-Type: application/logplex-1" \
    -H "Logplex-Msg-Count: 1" \
    -d "116 <134>1 2012-12-10T03:00:48.123456Z erlang t.feff49f1-4d55-4c9e-aee1-2d2b10e69b42 
    console.1 - - Logsplat test message 1" \
    http://local:password@10.5.0.4:8601/logs
    ```
3. drop into a remote console and verify the channel cache exists
    ```
    docker exec -it logplex_logplex1_1 bash -c "TERM=xterm bin/connect"
    (logplex@10.5.0.4)13> ets:lookup(channels, <<"1">>).
    [{channel,<<"1">>,<<>>,[]}]
    ```
4. drop into redis and watch the spool expire
    ```
    docker exec -it logplex_db_1 redis-cli
    redis 127.0.0.1:6379> expire "ch:1:spool" 10
    (integer) 1
    redis 127.0.0.1:6379> ttl "ch:1:spool"
    (integer) 8
    ```
5. after the spool expires, notice the channel cache is gone
    ```
    (logplex@10.5.0.4)8> ets:lookup(channels, <<"1">>).
    []
    ```
6. also notice that posting logs no longer works, we see this in the logs
    ```
    logplex1_1   | pid=<0.1102.0> m=logplex_message ln=77 class=info at=process_msg channel_id=1 msg=unknown_channel
    ```

This fixes the issue by catching the spool expiration and ignoring it. Deleting the ch:1:data key will still delete the channel as expected.